### PR TITLE
DropDown label now clear when value is empty string

### DIFF
--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -106,6 +106,8 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
         const _label = list.find((_) => _.value === value)?.label;
         if (_label) {
           setDisplayValue(_label);
+        } else {
+          setDisplayValue('');
         }
       }
     }, [list, value]);


### PR DESCRIPTION
Hi! I noticed that DropDown is not clearing the field label when the value is set to an empty string. So I made this change. I hope it helps!