### PR TITLE
Fixes bug in multiselect dropdown selection

### DIFF
--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -98,7 +98,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
     useEffect(() => {
       if (multiSelect) {
         const _labels = list
-          .filter((_) => value.indexOf(_.value) !== -1)
+          .filter((_) => isActive(_.value))
           .map((_) => _.label)
           .join(", ");
         setDisplayValue(_labels);
@@ -113,7 +113,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
     const isActive = useCallback(
       (currentValue: any) => {
         if (multiSelect) {
-          return value.indexOf(currentValue) !== -1;
+          return value.split(",").indexOf(currentValue) !== -1;
         } else {
           return value === currentValue;
         }
@@ -124,8 +124,8 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
     const setActive = useCallback(
       (currentValue: any) => {
         if (multiSelect) {
-          const valueIndex = value.indexOf(currentValue);
           const values = value.split(",");
+          const valueIndex = values.indexOf(currentValue);
           if (valueIndex === -1) {
             setValue([...values, currentValue].join(","));
           } else {


### PR DESCRIPTION
### Expected Behavior:
When I select an option in a multiselect question, I expect only that option's selection state to be changed.

### Actual Behavior:
If there are two options, "Option A" and "Option AB", and I select "Option AB", the multiselect component will display both options as selected, even though only one option was selected. Also, if "Option AB" is selected, "Option A" cannot be unselected.

### Steps to Reproduce:
1. Pass in the following list of options:
```
[
  { label: "Cheese, meat, and crackers", value: "Cheese, meat, and crackers" },
  { label: "Cheese and crackers", value: "Cheese and crackers" },
  { label: "Cheese", value: "Cheese" }
]
```
2. Select either of the first two options
3. Note the following:
  - The display value and selected options include the last option
  - The last option cannot be deselected while one of the first two options is selected

### Cause:
string.indexOf() is being called on the csv value string looking for each option to see if it is active. This fails when one option is a substring of another option.

### Solution:
Change methods to first split the csv value string into an array of values and then call indexOf on that array instead. This results in a strict comparison with each value that prevents the described issue.