### PR TITLE
bug fix - local state in setValue could be stale

### DIFF
--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -137,7 +137,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
           setValue(currentValue);
         }
       },
-      [value]
+      [value, setValue]
     );
 
     return (


### PR DESCRIPTION
issue: https://github.com/fateh999/react-native-paper-dropdown/issues/49 The setValue callback (along with the state taken in because of closure) is retained in the useCallBack. The fix is to add setValue to dependency list.