### PR TITLE
Set default display value to the passed in value

### DIFF
--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -83,7 +83,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
       dropDownItemSelectedTextStyle,
       accessibilityLabel,
     } = props;
-    const [displayValue, setDisplayValue] = useState("");
+    const [displayValue, setDisplayValue] = useState(value);
     const [inputLayout, setInputLayout] = useState({
       height: 0,
       width: 0,


### PR DESCRIPTION
This keeps the label animation from happening when you already have a default value.