### PR TITLE
Added keyboardShouldPersistTaps prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/DropDown.js",
   "types": "dist/DropDown.d.ts",
   "scripts": {
+    "preinstall": "npm run build",
     "build": "tsc"
   },
   "repository": {

--- a/src/DropDown.tsx
+++ b/src/DropDown.tsx
@@ -53,6 +53,7 @@ export interface DropDownPropsInterface {
   dropDownItemStyle?: ViewStyle;
   dropDownItemTextStyle?: TextStyle;
   accessibilityLabel?: string;
+  keyboardShouldPersistTaps?: 'never' | 'always' | 'handled' | undefined;
 }
 
 type TextInputPropsWithoutTheme = Without<TextInputProps, "theme">;
@@ -82,6 +83,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
       dropDownItemTextStyle,
       dropDownItemSelectedTextStyle,
       accessibilityLabel,
+      keyboardShouldPersistTaps,
     } = props;
     const [displayValue, setDisplayValue] = useState("");
     const [inputLayout, setInputLayout] = useState({
@@ -177,6 +179,7 @@ const DropDown = forwardRef<TouchableWithoutFeedback, DropDownPropsInterface>(
       >
         <ScrollView
           bounces={false}
+          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           style={{
             ...(dropDownContainerHeight
               ? {


### PR DESCRIPTION
I encountered a problem when there is Dropdown and TextInput on the same screen. 

Scenario: TextInput is focused and keyboard is open.

Action -- tap on Dropdown, the dropdown menu opens as expected Next, ton a menu option. 

Expected: The option should be selected

Actual: Instead, the keyboard is dismissed, and the menu remains open. An additional tap on the menu option is needed to select it

Solution: set keyboardShouldPersistTaps='handled' or 'always' to the ScrollView inside the menu prevents the keyboard from being dismissed and the tap going through to the menu option. 

I have exposed this prop as a prop of Dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

New Features:
- Enhanced the DropDown component with a new optional property `keyboardShouldPersistTaps`. This allows users to control whether the keyboard should stay visible after a tap. This feature improves user interaction with the component, especially in scenarios where continuous typing is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->