### PR TITLE
feat: add hideMenuHeader and statusBarHeight props

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,49 +103,53 @@ export default function App() {
 
 ### `DropdownProps`
 
-| Prop                  | Type                                                              | Description                                    |
-| --------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
-| `value`               | `string`                                                          | The currently selected value.                  |
-| `onSelect`            | `(value: string) => void`                                         | Callback function to handle value selection.   |
-| `options`             | `Option[]`                                                        | Array of options for the dropdown.             |
-| `menuUpIcon`          | `JSX.Element`                                                     | Custom icon for menu up state.                 |
-| `menuDownIcon`        | `JSX.Element`                                                     | Custom icon for menu down state.               |
-| `maxMenuHeight`       | `number`                                                          | Maximum height of the dropdown menu.           |
-| `menuContentStyle`    | `ViewStyle`                                                       | Style for the dropdown menu content.           |
-| `CustomDropdownItem`  | `(props: DropdownItemProps) => JSX.Element`                       | Custom component for dropdown item.            |
-| `CustomDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for dropdown input.           |
-| `CustomMenuHeader`    | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header. |
-| `Touchable`           | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.   |
-| `testID`              | `string`                                                          | Test ID for the dropdown component.            |
-| `menuTestID`          | `string`                                                          | Test ID for the dropdown menu.                 |
-| `placeholder`         | `string`                                                          | Placeholder text for the dropdown input.       |
-| `label`               | `TextInputLabelProp`                                              | Label for the dropdown input.                  |
-| `mode`                | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                   |
-| `disabled`            | `boolean`                                                         | Whether the dropdown is disabled.              |
-| `error`               | `boolean`                                                         | Whether the dropdown has an error.             |
+| Prop                  | Type                                                              | Description                                          |
+| --------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| `testID`              | `string`                                                          | Test ID for the dropdown component.                  |
+| `menuTestID`          | `string`                                                          | Test ID for the dropdown menu.                       |
+| `value`               | `string`                                                          | The currently selected value.                        |
+| `onSelect`            | `(value: string) => void`                                         | Callback function to handle value selection.         |
+| `options`             | `Option[]`                                                        | Array of options for the dropdown.                   |
+| `menuUpIcon`          | `JSX.Element`                                                     | Custom icon for menu up state.                       |
+| `menuDownIcon`        | `JSX.Element`                                                     | Custom icon for menu down state.                     |
+| `maxMenuHeight`       | `number`                                                          | Maximum height of the dropdown menu.                 |
+| `menuContentStyle`    | `ViewStyle`                                                       | Style for the dropdown menu content.                 |
+| `CustomDropdownItem`  | `(props: DropdownItemProps) => JSX.Element`                       | Custom component for dropdown item.                  |
+| `CustomDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for dropdown input.                 |
+| `CustomMenuHeader`    | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.       |
+| `Touchable`           | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.         |
+| `placeholder`         | `string`                                                          | Placeholder text for the dropdown input.             |
+| `label`               | `TextInputLabelProp`                                              | Label for the dropdown input.                        |
+| `mode`                | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                         |
+| `disabled`            | `boolean`                                                         | Whether the dropdown is disabled.                    |
+| `error`               | `boolean`                                                         | Whether the dropdown has an error.                   |
+| `hideMenuHeader`      | `boolean`                                                         | Hide menu header component (default: false).         |
+| `statusBarHeight`     | `number`                                                          | Additional top margin for the status bar on Android. |
 
 ### `MultiSelectDropdownProps`
 
-| Prop                             | Type                                                              | Description                                       |
-| -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------- |
-| `value`                          | `string[]`                                                        | The currently selected values.                    |
-| `onSelect`                       | `(value: string[]) => void`                                       | Callback function to handle value selection.      |
-| `options`                        | `Option[]`                                                        | Array of options for the dropdown.                |
-| `menuUpIcon`                     | `JSX.Element`                                                     | Custom icon for menu up state.                    |
-| `menuDownIcon`                   | `JSX.Element`                                                     | Custom icon for menu down state.                  |
-| `Touchable`                      | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.      |
-| `maxMenuHeight`                  | `number`                                                          | Maximum height of the dropdown menu.              |
-| `menuContentStyle`               | `ViewStyle`                                                       | Style for the dropdown menu content.              |
-| `CustomMultiSelectDropdownItem`  | `(props: MultiSelectDropdownItemProps) => JSX.Element`            | Custom component for multi-select dropdown item.  |
-| `CustomMultiSelectDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for multi-select dropdown input. |
-| `CustomMenuHeader`               | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.    |
-| `testID`                         | `string`                                                          | Test ID for the dropdown component.               |
-| `menuTestID`                     | `string`                                                          | Test ID for the dropdown menu.                    |
-| `placeholder`                    | `string`                                                          | Placeholder text for the dropdown input.          |
-| `label`                          | `TextInputLabelProp`                                              | Label for the dropdown input.                     |
-| `mode`                           | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                      |
-| `disabled`                       | `boolean`                                                         | Whether the dropdown is disabled.                 |
-| `error`                          | `boolean`                                                         | Whether the dropdown has an error.                |
+| Prop                             | Type                                                              | Description                                          |
+| -------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| `testID`                         | `string`                                                          | Test ID for the dropdown component.                  |
+| `menuTestID`                     | `string`                                                          | Test ID for the dropdown menu.                       |
+| `value`                          | `string[]`                                                        | The currently selected values.                       |
+| `onSelect`                       | `(value: string[]) => void`                                       | Callback function to handle value selection.         |
+| `options`                        | `Option[]`                                                        | Array of options for the dropdown.                   |
+| `menuUpIcon`                     | `JSX.Element`                                                     | Custom icon for menu up state.                       |
+| `menuDownIcon`                   | `JSX.Element`                                                     | Custom icon for menu down state.                     |
+| `Touchable`                      | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.         |
+| `maxMenuHeight`                  | `number`                                                          | Maximum height of the dropdown menu.                 |
+| `menuContentStyle`               | `ViewStyle`                                                       | Style for the dropdown menu content.                 |
+| `CustomMultiSelectDropdownItem`  | `(props: MultiSelectDropdownItemProps) => JSX.Element`            | Custom component for multi-select dropdown item.     |
+| `CustomMultiSelectDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for multi-select dropdown input.    |
+| `CustomMenuHeader`               | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.       |
+| `placeholder`                    | `string`                                                          | Placeholder text for the dropdown input.             |
+| `label`                          | `TextInputLabelProp`                                              | Label for the dropdown input.                        |
+| `mode`                           | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                         |
+| `disabled`                       | `boolean`                                                         | Whether the dropdown is disabled.                    |
+| `error`                          | `boolean`                                                         | Whether the dropdown has an error.                   |
+| `hideMenuHeader`                 | `boolean`                                                         | Hide menu header component (default: false).         |
+| `statusBarHeight`                | `number`                                                          | Additional top margin for the status bar on Android. |
 
 ## Methods
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -288,49 +288,53 @@ const styles = StyleSheet.create({
 
 ### `DropdownProps`
 
-| Prop                  | Type                                                              | Description                                    |
-| --------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
-| `value`               | `string`                                                          | The currently selected value.                  |
-| `onSelect`            | `(value: string) => void`                                         | Callback function to handle value selection.   |
-| `options`             | `Option[]`                                                        | Array of options for the dropdown.             |
-| `menuUpIcon`          | `JSX.Element`                                                     | Custom icon for menu up state.                 |
-| `menuDownIcon`        | `JSX.Element`                                                     | Custom icon for menu down state.               |
-| `maxMenuHeight`       | `number`                                                          | Maximum height of the dropdown menu.           |
-| `menuContentStyle`    | `ViewStyle`                                                       | Style for the dropdown menu content.           |
-| `CustomDropdownItem`  | `(props: DropdownItemProps) => JSX.Element`                       | Custom component for dropdown item.            |
-| `CustomDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for dropdown input.           |
-| `CustomMenuHeader`    | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header. |
-| `Touchable`           | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.   |
-| `testID`              | `string`                                                          | Test ID for the dropdown component.            |
-| `menuTestID`          | `string`                                                          | Test ID for the dropdown menu.                 |
-| `placeholder`         | `string`                                                          | Placeholder text for the dropdown input.       |
-| `label`               | `TextInputLabelProp`                                              | Label for the dropdown input.                  |
-| `mode`                | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                   |
-| `disabled`            | `boolean`                                                         | Whether the dropdown is disabled.              |
-| `error`               | `boolean`                                                         | Whether the dropdown has an error.             |
+| Prop                  | Type                                                              | Description                                          |
+| --------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| `testID`              | `string`                                                          | Test ID for the dropdown component.                  |
+| `menuTestID`          | `string`                                                          | Test ID for the dropdown menu.                       |
+| `value`               | `string`                                                          | The currently selected value.                        |
+| `onSelect`            | `(value: string) => void`                                         | Callback function to handle value selection.         |
+| `options`             | `Option[]`                                                        | Array of options for the dropdown.                   |
+| `menuUpIcon`          | `JSX.Element`                                                     | Custom icon for menu up state.                       |
+| `menuDownIcon`        | `JSX.Element`                                                     | Custom icon for menu down state.                     |
+| `maxMenuHeight`       | `number`                                                          | Maximum height of the dropdown menu.                 |
+| `menuContentStyle`    | `ViewStyle`                                                       | Style for the dropdown menu content.                 |
+| `CustomDropdownItem`  | `(props: DropdownItemProps) => JSX.Element`                       | Custom component for dropdown item.                  |
+| `CustomDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for dropdown input.                 |
+| `CustomMenuHeader`    | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.       |
+| `Touchable`           | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.         |
+| `placeholder`         | `string`                                                          | Placeholder text for the dropdown input.             |
+| `label`               | `TextInputLabelProp`                                              | Label for the dropdown input.                        |
+| `mode`                | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                         |
+| `disabled`            | `boolean`                                                         | Whether the dropdown is disabled.                    |
+| `error`               | `boolean`                                                         | Whether the dropdown has an error.                   |
+| `hideMenuHeader`      | `boolean`                                                         | Hide menu header component (default: false).         |
+| `statusBarHeight`     | `number`                                                          | Additional top margin for the status bar on Android. |
 
 ### `MultiSelectDropdownProps`
 
-| Prop                             | Type                                                              | Description                                       |
-| -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------- |
-| `value`                          | `string[]`                                                        | The currently selected values.                    |
-| `onSelect`                       | `(value: string[]) => void`                                       | Callback function to handle value selection.      |
-| `options`                        | `Option[]`                                                        | Array of options for the dropdown.                |
-| `menuUpIcon`                     | `JSX.Element`                                                     | Custom icon for menu up state.                    |
-| `menuDownIcon`                   | `JSX.Element`                                                     | Custom icon for menu down state.                  |
-| `Touchable`                      | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.      |
-| `maxMenuHeight`                  | `number`                                                          | Maximum height of the dropdown menu.              |
-| `menuContentStyle`               | `ViewStyle`                                                       | Style for the dropdown menu content.              |
-| `CustomMultiSelectDropdownItem`  | `(props: MultiSelectDropdownItemProps) => JSX.Element`            | Custom component for multi-select dropdown item.  |
-| `CustomMultiSelectDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for multi-select dropdown input. |
-| `CustomMenuHeader`               | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.    |
-| `testID`                         | `string`                                                          | Test ID for the dropdown component.               |
-| `menuTestID`                     | `string`                                                          | Test ID for the dropdown menu.                    |
-| `placeholder`                    | `string`                                                          | Placeholder text for the dropdown input.          |
-| `label`                          | `TextInputLabelProp`                                              | Label for the dropdown input.                     |
-| `mode`                           | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                      |
-| `disabled`                       | `boolean`                                                         | Whether the dropdown is disabled.                 |
-| `error`                          | `boolean`                                                         | Whether the dropdown has an error.                |
+| Prop                             | Type                                                              | Description                                          |
+| -------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| `testID`                         | `string`                                                          | Test ID for the dropdown component.                  |
+| `menuTestID`                     | `string`                                                          | Test ID for the dropdown menu.                       |
+| `value`                          | `string[]`                                                        | The currently selected values.                       |
+| `onSelect`                       | `(value: string[]) => void`                                       | Callback function to handle value selection.         |
+| `options`                        | `Option[]`                                                        | Array of options for the dropdown.                   |
+| `menuUpIcon`                     | `JSX.Element`                                                     | Custom icon for menu up state.                       |
+| `menuDownIcon`                   | `JSX.Element`                                                     | Custom icon for menu down state.                     |
+| `Touchable`                      | `ForwardRefExoticComponent<PressableProps & RefAttributes<View>>` | Custom touchable component for the dropdown.         |
+| `maxMenuHeight`                  | `number`                                                          | Maximum height of the dropdown menu.                 |
+| `menuContentStyle`               | `ViewStyle`                                                       | Style for the dropdown menu content.                 |
+| `CustomMultiSelectDropdownItem`  | `(props: MultiSelectDropdownItemProps) => JSX.Element`            | Custom component for multi-select dropdown item.     |
+| `CustomMultiSelectDropdownInput` | `(props: DropdownInputProps) => JSX.Element`                      | Custom component for multi-select dropdown input.    |
+| `CustomMenuHeader`               | `(props: DropdownHeaderProps) => JSX.Element`                     | Custom component for the dropdown menu header.       |
+| `placeholder`                    | `string`                                                          | Placeholder text for the dropdown input.             |
+| `label`                          | `TextInputLabelProp`                                              | Label for the dropdown input.                        |
+| `mode`                           | `'flat' \| 'outlined'`                                            | Mode for the dropdown input.                         |
+| `disabled`                       | `boolean`                                                         | Whether the dropdown is disabled.                    |
+| `error`                          | `boolean`                                                         | Whether the dropdown has an error.                   |
+| `hideMenuHeader`                 | `boolean`                                                         | Hide menu header component (default: false).         |
+| `statusBarHeight`                | `number`                                                          | Additional top margin for the status bar on Android. |
 
 ## Methods
 

--- a/src/dropdown.tsx
+++ b/src/dropdown.tsx
@@ -23,6 +23,7 @@ function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
     statusBarHeight = Platform.OS === 'android'
       ? StatusBar.currentHeight
       : undefined,
+    hideMenuHeader = false,
     Touchable = TouchableRipple,
     disabled = false,
     error = false,
@@ -89,7 +90,7 @@ function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
       contentStyle={[contentStyle, menuContentStyle]}
       testID={menuTestID}
     >
-      {!props.hideMenuHeader && (
+      {!hideMenuHeader && (
         <CustomMenuHeader
           label={label}
           toggleMenu={toggleMenu}

--- a/src/dropdown.tsx
+++ b/src/dropdown.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, StatusBar, View } from 'react-native';
 import { Menu, TextInput, TouchableRipple } from 'react-native-paper';
 import DropdownItem from './dropdown-item';
 import DropdownInput from './dropdown-input';
@@ -9,6 +9,8 @@ import DropdownHeader from './dropdown-header';
 
 function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
   const {
+    testID,
+    menuTestID,
     options,
     mode,
     placeholder,
@@ -16,16 +18,17 @@ function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
     menuUpIcon = <TextInput.Icon icon={'menu-up'} pointerEvents="none" />,
     menuDownIcon = <TextInput.Icon icon={'menu-down'} pointerEvents="none" />,
     value,
-    onSelect,
     maxMenuHeight,
     menuContentStyle,
-    CustomDropdownItem = DropdownItem,
-    CustomDropdownInput = DropdownInput,
+    statusBarHeight = Platform.OS === 'android'
+      ? StatusBar.currentHeight
+      : undefined,
     Touchable = TouchableRipple,
     disabled = false,
     error = false,
-    testID,
-    menuTestID,
+    onSelect,
+    CustomDropdownItem = DropdownItem,
+    CustomDropdownInput = DropdownInput,
     CustomMenuHeader = DropdownHeader,
   } = props;
   const selectedLabel = options.find((option) => option.value === value)?.label;
@@ -61,6 +64,7 @@ function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
       onDismiss={toggleMenu}
       style={menuStyle}
       elevation={5}
+      statusBarHeight={statusBarHeight}
       keyboardShouldPersistTaps={'handled'}
       anchor={
         <Touchable
@@ -85,13 +89,15 @@ function Dropdown(props: DropdownProps, ref: React.Ref<DropdownRef>) {
       contentStyle={[contentStyle, menuContentStyle]}
       testID={menuTestID}
     >
-      <CustomMenuHeader
-        label={label}
-        toggleMenu={toggleMenu}
-        resetMenu={resetMenu}
-        value={value}
-        multiSelect={false}
-      />
+      {!props.hideMenuHeader && (
+        <CustomMenuHeader
+          label={label}
+          toggleMenu={toggleMenu}
+          resetMenu={resetMenu}
+          value={value}
+          multiSelect={false}
+        />
+      )}
       <ScrollView style={scrollViewStyle} bounces={false}>
         {options.map((option, index) => {
           return (

--- a/src/multi-select-dropdown.tsx
+++ b/src/multi-select-dropdown.tsx
@@ -26,6 +26,7 @@ function MultiSelectDropdown(
     statusBarHeight = Platform.OS === 'android'
       ? StatusBar.currentHeight
       : undefined,
+    hideMenuHeader = false,
     Touchable = TouchableRipple,
     disabled = false,
     error = false,
@@ -99,7 +100,7 @@ function MultiSelectDropdown(
       }
       contentStyle={menuContentStyle}
     >
-      {!props.hideMenuHeader && (
+      {!hideMenuHeader && (
         <CustomMenuHeader
           label={label}
           toggleMenu={toggleMenu}

--- a/src/multi-select-dropdown.tsx
+++ b/src/multi-select-dropdown.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useImperativeHandle, useMemo } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, StatusBar, View } from 'react-native';
 import { Menu, TextInput, TouchableRipple } from 'react-native-paper';
 import DropdownInput from './dropdown-input';
 import MultiSelectDropdownItem from './multi-select-dropdown-item';
@@ -12,6 +12,8 @@ function MultiSelectDropdown(
   ref: React.Ref<DropdownRef>
 ) {
   const {
+    testID,
+    menuTestID,
     options,
     mode,
     placeholder,
@@ -19,16 +21,17 @@ function MultiSelectDropdown(
     menuUpIcon = <TextInput.Icon icon={'menu-up'} pointerEvents="none" />,
     menuDownIcon = <TextInput.Icon icon={'menu-down'} pointerEvents="none" />,
     value = [],
-    onSelect,
     menuContentStyle = { paddingVertical: 0 },
     maxMenuHeight,
-    CustomMultiSelectDropdownItem = MultiSelectDropdownItem,
-    CustomMultiSelectDropdownInput = DropdownInput,
+    statusBarHeight = Platform.OS === 'android'
+      ? StatusBar.currentHeight
+      : undefined,
     Touchable = TouchableRipple,
     disabled = false,
     error = false,
-    testID,
-    menuTestID,
+    onSelect,
+    CustomMultiSelectDropdownItem = MultiSelectDropdownItem,
+    CustomMultiSelectDropdownInput = DropdownInput,
     CustomMenuHeader = DropdownHeader,
   } = props;
 
@@ -72,6 +75,7 @@ function MultiSelectDropdown(
       onDismiss={toggleMenu}
       style={menuStyle}
       elevation={5}
+      statusBarHeight={statusBarHeight}
       keyboardShouldPersistTaps={'handled'}
       anchor={
         <Touchable
@@ -95,13 +99,15 @@ function MultiSelectDropdown(
       }
       contentStyle={menuContentStyle}
     >
-      <CustomMenuHeader
-        label={label}
-        toggleMenu={toggleMenu}
-        resetMenu={resetMenu}
-        value={value}
-        multiSelect
-      />
+      {!props.hideMenuHeader && (
+        <CustomMenuHeader
+          label={label}
+          toggleMenu={toggleMenu}
+          resetMenu={resetMenu}
+          value={value}
+          multiSelect
+        />
+      )}
       <ScrollView style={scrollViewStyle} bounces={false}>
         {options.map((option, index) => {
           return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,44 +19,48 @@ export type Option = {
 };
 
 export type DropdownProps = {
+  testID?: string;
+  menuTestID?: string;
   value?: string;
-  onSelect?: (value?: string) => void;
   options: Option[];
   menuUpIcon?: JSX.Element;
   menuDownIcon?: JSX.Element;
   maxMenuHeight?: number;
   menuContentStyle?: ViewStyle;
-  CustomMenuHeader?: (props: DropdownHeaderProps) => JSX.Element;
-  CustomDropdownItem?: (props: DropdownItemProps) => JSX.Element;
-  CustomDropdownInput?: (props: DropdownInputProps) => JSX.Element;
+  hideMenuHeader?: boolean;
+  statusBarHeight?: number;
   Touchable?: ForwardRefExoticComponent<
     PressableProps & React.RefAttributes<View>
   >;
-  testID?: string;
-  menuTestID?: string;
+  onSelect?: (value?: string) => void;
+  CustomMenuHeader?: (props: DropdownHeaderProps) => JSX.Element;
+  CustomDropdownItem?: (props: DropdownItemProps) => JSX.Element;
+  CustomDropdownInput?: (props: DropdownInputProps) => JSX.Element;
 } & Pick<
   TextInputProps,
   'placeholder' | 'label' | 'mode' | 'disabled' | 'error'
 >;
 
 export type MultiSelectDropdownProps = {
+  testID?: string;
+  menuTestID?: string;
   value?: string[];
-  onSelect?: (value: string[]) => void;
   options: Option[];
   menuUpIcon?: JSX.Element;
   menuDownIcon?: JSX.Element;
-  CustomMenuHeader?: (props: DropdownHeaderProps) => JSX.Element;
+  maxMenuHeight?: number;
+  menuContentStyle?: ViewStyle;
+  hideMenuHeader?: boolean;
+  statusBarHeight?: number;
   Touchable?: ForwardRefExoticComponent<
     PressableProps & React.RefAttributes<View>
   >;
-  maxMenuHeight?: number;
-  menuContentStyle?: ViewStyle;
+  onSelect?: (value: string[]) => void;
+  CustomMenuHeader?: (props: DropdownHeaderProps) => JSX.Element;
   CustomMultiSelectDropdownItem?: (
     props: MultiSelectDropdownItemProps
   ) => JSX.Element;
   CustomMultiSelectDropdownInput?: (props: DropdownInputProps) => JSX.Element;
-  testID?: string;
-  menuTestID?: string;
 } & Pick<
   TextInputProps,
   'placeholder' | 'label' | 'mode' | 'disabled' | 'error'


### PR DESCRIPTION
I would like to add the `hideMenuHeader` property to hide the menu header, so that it doesn't break the design of the applications.

Also, as an additional feature, I would like to add the `statusBarHeight` property since in Android it happens that the height of the status bar is not calculated when it is translucent, here are some examples of this:

## Without `statusBarHeight`

https://github.com/user-attachments/assets/efa246ec-8e28-4b1d-aea2-2a8ba74dc6d2

## With `statusBarHeight`

https://github.com/user-attachments/assets/e2fa37e9-bb20-477f-9573-7079edb494e7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new properties `hideMenuHeader` and `statusBarHeight` for `Dropdown` and `MultiSelectDropdown` components, enabling better control over display and layout adjustments.

- **Improvements**
  - Enhanced the flexibility and usability of dropdown components through improved prop management and conditional rendering of headers.

- **Documentation**
  - Updated the README to reflect new configuration options and improved property organization for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->