### PR TITLE
Fix item text on dark mode

### DIFF
--- a/src/dropdown-item.tsx
+++ b/src/dropdown-item.tsx
@@ -13,12 +13,12 @@ function DropdownItem(props: DropdownItemProps) {
       color:
         value === option.value
           ? theme.colors.primary
-          : theme.colors.onBackground,
+          : theme.colors.onSurface,
       width: width,
     }),
     [
       option.value,
-      theme.colors.onBackground,
+      theme.colors.onSurface,
       theme.colors.primary,
       value,
       width,


### PR DESCRIPTION
Without this change the item text is black on a already very dark background.

Before:
<img width="405" alt="Screenshot 2025-02-19 at 4 53 18 PM" src="https://github.com/user-attachments/assets/fa2446e4-7bc1-4fac-a8b5-0955e8a467ec" />

After:
<img width="408" alt="Screenshot 2025-02-19 at 4 52 56 PM" src="https://github.com/user-attachments/assets/8db4d857-4c4f-4a76-b8d9-b2f2872527f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the visual design of dropdown items so that unselected options now exhibit a refreshed color scheme for greater visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->